### PR TITLE
Standard søkestreng skal være tom

### DIFF
--- a/src/layouts/Default/index.js
+++ b/src/layouts/Default/index.js
@@ -97,7 +97,7 @@ export function DefaultLayout (props) {
                 inputRef={searchFieldRef}
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
-                onSearch={() => { window.location.replace(`/${ROUTES.students}?s=${searchTerm}`) }}
+                onSearch={() => { window.location.replace(`/${ROUTES.students}?s=${searchTerm || ''}`) }}
                 placeholder='Søk etter elev ...'
                 className='search-input'
                 rounded
@@ -162,7 +162,7 @@ export function DefaultLayout (props) {
               <SearchField
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
-                onSearch={() => { window.location.replace(`/${ROUTES.students}?s=${searchTerm}`) }}
+                onSearch={() => { window.location.replace(`/${ROUTES.students}?s=${searchTerm || ''}`) }}
                 placeholder='Søk etter elev ...'
                 className='search-input'
                 rounded


### PR DESCRIPTION
Om man trykker på søkeknappen uten at det står noe i søkefeltet går ting på trynet..
Denne endringen setter standard søketerm til Tom Streng (_"sjåfør, på utsiden!"_), for å unngå at den er null og tryner hele opplegget..