### PR TITLE
Filtrer kontaktpersoner og pårørende for tomme objekter

### DIFF
--- a/src/lib/repack-yff-bekreftelse.js
+++ b/src/lib/repack-yff-bekreftelse.js
@@ -25,7 +25,7 @@ function repackBekreftelse (data) {
     telefon: arrify(bekreftelse.kontaktpersonTelefon),
     epost: arrify(bekreftelse.kontaktpersonEpost),
     avdeling: arrify(bekreftelse.kontaktpersonAvdeling)
-  }).filter(kontakt => kontakt && (Object.keys(kontakt).length !== 0 && kontakt.navn))
+  }).filter(kontakt => kontakt && Object.keys(kontakt).length !== 0 && kontakt.navn)
 
   // cleanup kontaktpersoner
   delete bekreftelse.kontaktpersonNavn
@@ -37,7 +37,7 @@ function repackBekreftelse (data) {
   bekreftelse.parorendeData = mergeArrays({
     navn: arrify(bekreftelse.parorendeNavn),
     telefon: arrify(bekreftelse.parorendeTelefon)
-  }).filter(kontakt => kontakt && (Object.keys(kontakt).length !== 0 && kontakt.navn))
+  }).filter(kontakt => kontakt && Object.keys(kontakt).length !== 0 && kontakt.navn)
 
   // cleanup pårørende
   delete bekreftelse.parorendeNavn

--- a/src/lib/repack-yff-bekreftelse.js
+++ b/src/lib/repack-yff-bekreftelse.js
@@ -25,7 +25,8 @@ function repackBekreftelse (data) {
     telefon: arrify(bekreftelse.kontaktpersonTelefon),
     epost: arrify(bekreftelse.kontaktpersonEpost),
     avdeling: arrify(bekreftelse.kontaktpersonAvdeling)
-  }).filter(kontakt => kontakt && Object.keys(kontakt).length !== 0)
+  }).filter(kontakt => kontakt && (Object.keys(kontakt).length !== 0 && kontakt.navn))
+
   // cleanup kontaktpersoner
   delete bekreftelse.kontaktpersonNavn
   delete bekreftelse.kontaktpersonTelefon
@@ -36,7 +37,8 @@ function repackBekreftelse (data) {
   bekreftelse.parorendeData = mergeArrays({
     navn: arrify(bekreftelse.parorendeNavn),
     telefon: arrify(bekreftelse.parorendeTelefon)
-  }).filter(kontakt => kontakt && Object.keys(kontakt).length !== 0)
+  }).filter(kontakt => kontakt && (Object.keys(kontakt).length !== 0 && kontakt.navn))
+
   // cleanup pårørende
   delete bekreftelse.parorendeNavn
   delete bekreftelse.parorendeTelefon


### PR DESCRIPTION
Sjekk at det er angitt en verdi i kontaktobjektene for å unngå tomme objekter.

Eksempel etter fix:
![image](https://user-images.githubusercontent.com/13292913/106619470-ebb23780-6570-11eb-8a42-b674b16b4fea.png)


Fixes #224