### PR TITLE
Småfikser

### DIFF
--- a/src/containers/YffConfirmationModal/index.js
+++ b/src/containers/YffConfirmationModal/index.js
@@ -197,7 +197,7 @@ export function YffConfirmationModal ({ student, ...props }) {
     setErrors(formErrors)
 
     const hasSubError = Object.keys(subErrors).filter(key => Object.keys(subErrors[key]).filter(index => !!subErrors[key][index]).length > 0).length > 0
-    return !!formErrors && hasSubError
+    return !!formErrors || hasSubError
   }
 
   function generateDocument (data) {

--- a/src/pages/Student/index.js
+++ b/src/pages/Student/index.js
@@ -47,7 +47,11 @@ export function Student ({ match, ...props }) {
 
   async function getDocuments () {
     const docs = await apiGet(API.URL + '/students/' + id + '/documents')
-    if (!docs.data || !Array.isArray(docs.data)) return
+    if (!docs || !docs.data || !Array.isArray(docs.data)) {
+      setDocuments([])
+      setNotes([])
+      return
+    }
     // TODO: Display error message
 
     const docsOrderedByModified = docs.data.sort((a, b) => (a.modified[0].timestamp < b.modified[0].timestamp) ? 1 : -1)


### PR DESCRIPTION
- Forhindre innsending av YFF bekreftelsesskjema dersom bare formErrors eller bare subErrors eksisterer. Tidligere måtte det være feil begge steder for at innsendelsen ble avbrutt. Dette medførte at dersom det kun var èn feil i formen eller i sub, så ble ikke innsendingen forhindret!
- Feilhåndtering når ingen dokumenter returneres eller noe annet enn forventet returneres.