### PR TITLE
Fjern status

### DIFF
--- a/src/pages/ActivityLog/index.js
+++ b/src/pages/ActivityLog/index.js
@@ -16,7 +16,6 @@ import { PreviewDocumentModal } from '../../containers/PreviewDocumentModal'
 
 import './styles.scss'
 import repackDocumentType from '../../lib/repack-document-type'
-import repackDocumentStatus from '../../lib/repack-document-status'
 
 export function ActivityLog () {
   const [documentModalState, setDocumentModalState] = useState(false)
@@ -117,7 +116,6 @@ export function ActivityLog () {
                   <th><Paragraph size='small'>Elev</Paragraph></th>
                   <th><Paragraph size='small'>Dokumenttype</Paragraph></th>
                   <th><Paragraph size='small'>Dato</Paragraph></th>
-                  <th><Paragraph size='small'>Status</Paragraph></th>
                   <th><Paragraph size='small'>Sendt av</Paragraph></th>
                   <th className='actions-th'><Paragraph size='small'>Ny handling</Paragraph></th>
                 </tr>
@@ -136,7 +134,6 @@ export function ActivityLog () {
                         </td>
                         <td><Skeleton randomWidth={[40, 90]} /></td>
                         <td><Skeleton width='90px' /></td>
-                        <td><Skeleton /></td>
                         <td width='200px'><Skeleton randomWidth={[40, 80]} /></td>
                         <td><Skeleton width='40%' /></td>
                       </tr>
@@ -165,9 +162,6 @@ export function ActivityLog () {
                         </td>
                         <td>
                           <Paragraph><Link tabIndex={-1} aria-label='Klikk for å åpne' aria-hidden onClick={() => openPreviewModal(doc)}><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Link></Paragraph>
-                        </td>
-                        <td>
-                          <Paragraph>{repackDocumentStatus(doc.status)}</Paragraph>
                         </td>
                         <td>
                           <Paragraph>{doc.teacher.name}</Paragraph>

--- a/src/pages/Class/basisgruppe.js
+++ b/src/pages/Class/basisgruppe.js
@@ -91,6 +91,9 @@ export function Basisgruppe ({ group, documents, conversations, notes }) {
                   <Paragraph><Link onClick={() => openPreviewModal(doc)} aria-label='Klikk for å åpne'>{repackDocumentType(doc.type, doc.variant)}</Link></Paragraph>
                 </td>
                 <td>
+                  <Paragraph><Link onClick={() => openPreviewModal(doc)} aria-label='Klikk for å åpne' tabIndex='-1'>{doc.content.period ? doc.content.period.nb : ''}</Link></Paragraph>
+                </td>
+                <td>
                   <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
                 </td>
               </tr>

--- a/src/pages/Class/basisgruppe.js
+++ b/src/pages/Class/basisgruppe.js
@@ -8,7 +8,6 @@ import ClassTile from '../../components/class-tile'
 import ClassTileGroup from '../../components/class-tile-group'
 
 import { ROUTES } from '../../config/constants'
-import repackDocumentStatus from '../../lib/repack-document-status'
 import repackDocumentType from '../../lib/repack-document-type'
 
 import { PreviewDocumentModal } from '../../containers/PreviewDocumentModal'
@@ -39,9 +38,6 @@ export function Basisgruppe ({ group, documents, conversations, notes }) {
         <ClassTile label='varselbrev' value={documents ? documents.length : 0} />
         <ClassTile label='dokumenterte elevsamtaler' value={conversations ? conversations.length : 0} />
         <ClassTile label='notater til elevmappa' value={notes ? notes.length : 0} />
-        {/* <ClassTile label='utplasseringer' value={0} />
-        <ClassTile label='lokale læreplaner arkivert' value={0} />
-        <ClassTile label='tilbakemeldinger' value={0} /> */}
       </ClassTileGroup>
 
       <ClassPanel icon='students' title='Elever'>
@@ -97,9 +93,6 @@ export function Basisgruppe ({ group, documents, conversations, notes }) {
                 <td>
                   <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
                 </td>
-                <td>
-                  <Paragraph>{repackDocumentStatus(doc.status)}</Paragraph>
-                </td>
               </tr>
             )
           })
@@ -131,11 +124,12 @@ export function Basisgruppe ({ group, documents, conversations, notes }) {
                   </div>
                 </td>
                 <td>
-                  <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
+                  <Paragraph><Link onClick={() => openPreviewModal(doc)} aria-label='Klikk for å åpne'>{doc.variant === 'samtale' ? 'Elevsamtale gjennomført' : 'Eleven ønsket ikke samtale'}</Link></Paragraph>
                 </td>
                 <td>
-                  <Paragraph>{repackDocumentStatus(doc.status, true)}</Paragraph>
+                  <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
                 </td>
+                <td />
               </tr>
             )
           })
@@ -167,10 +161,10 @@ export function Basisgruppe ({ group, documents, conversations, notes }) {
                   </div>
                 </td>
                 <td>
-                  <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
+                  <Paragraph>{doc.teacher.name}</Paragraph>
                 </td>
                 <td>
-                  <Paragraph>{repackDocumentStatus(doc.status, true)}</Paragraph>
+                  <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
                 </td>
               </tr>
             )

--- a/src/pages/Class/undervisningsgruppe.js
+++ b/src/pages/Class/undervisningsgruppe.js
@@ -109,6 +109,7 @@ export function Undervisningsgruppe ({ group, documents, loading }) {
                   </td>
                   <td><Skeleton /></td>
                   <td><Skeleton /></td>
+                  <td><Skeleton /></td>
                 </tr>
               )
             })
@@ -129,6 +130,9 @@ export function Undervisningsgruppe ({ group, documents, loading }) {
                 </td>
                 <td>
                   <Paragraph><Link onClick={() => openPreviewModal(doc)} aria-label='Klikk for å åpne'>{repackDocumentType(doc.type, doc.variant)}</Link></Paragraph>
+                </td>
+                <td>
+                  <Paragraph><Link onClick={() => openPreviewModal(doc)} aria-label='Klikk for å åpne' tabIndex='-1'>{doc.content.period ? doc.content.period.nb : ''}</Link></Paragraph>
                 </td>
                 <td>
                   <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>

--- a/src/pages/Class/undervisningsgruppe.js
+++ b/src/pages/Class/undervisningsgruppe.js
@@ -9,7 +9,6 @@ import ClassPanel from '../../components/class-panel'
 
 import { ROUTES } from '../../config/constants'
 import repackDocumentType from '../../lib/repack-document-type'
-import repackDocumentStatus from '../../lib/repack-document-status'
 
 import { PreviewDocumentModal } from '../../containers/PreviewDocumentModal'
 
@@ -43,7 +42,7 @@ export function Undervisningsgruppe ({ group, documents, loading }) {
                 <Skeleton variant='rectangle' height='126px' width='calc(100% / 3 - (32px))' style={{ marginLeft: '32px' }} />
                 <Skeleton variant='rectangle' height='126px' width='calc(100% / 3 - (32px))' style={{ marginLeft: '32px' }} />
               </>
-            )
+              )
             : <ClassTile label='varselbrev i faget' value={documents ? documents.length : <Skeleton width='70px' />} />
         }
       </ClassTileGroup>
@@ -110,7 +109,6 @@ export function Undervisningsgruppe ({ group, documents, loading }) {
                   </td>
                   <td><Skeleton /></td>
                   <td><Skeleton /></td>
-                  <td><Skeleton /></td>
                 </tr>
               )
             })
@@ -134,9 +132,6 @@ export function Undervisningsgruppe ({ group, documents, loading }) {
                 </td>
                 <td>
                   <Paragraph><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Paragraph>
-                </td>
-                <td>
-                  <Paragraph>{repackDocumentStatus(doc.status)}</Paragraph>
                 </td>
               </tr>
             )

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -16,7 +16,6 @@ import { PreviewDocumentModal } from '../../containers/PreviewDocumentModal'
 
 import './styles.scss'
 import repackDocumentType from '../../lib/repack-document-type'
-import repackDocumentStatus from '../../lib/repack-document-status'
 
 export function Home () {
   const { user } = useSession()
@@ -137,7 +136,6 @@ export function Home () {
                   <td><Skeleton randomWidth={[40, 70]} /></td>
                   <td><Skeleton width='60%' /></td>
                   <td><Skeleton /></td>
-                  <td><Skeleton /></td>
                 </tr>
               )
             })
@@ -167,9 +165,6 @@ export function Home () {
                   </td>
                   <td>
                     <Paragraph><Link tabIndex={-1} aria-label='Klikk for å åpne' aria-hidden onClick={() => openPreviewModal(doc)}><Moment locale='nb' format='DD. MMM YYYY'>{doc.created.timestamp}</Moment></Link></Paragraph>
-                  </td>
-                  <td>
-                    <Paragraph>{repackDocumentStatus(doc.status)}</Paragraph>
                   </td>
                   <td>
                     <IconDropdownNav>


### PR DESCRIPTION
Fjern status fra forsiden, aktivitetsloggen og klassesiden. Statusen er fremdeles tilgjengelig om man klikker seg inn i forhåndsvisningen av dokumentene.